### PR TITLE
Bugfix: Example causes standard input hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ color it currently has. If the response replies the same color that was set
 then it indicates truecolor is supported.
 
 ```bash
-$ (echo -e '\e[48:2:1:2:3m\eP$qm\e\\' ; xxd)
+$ (echo -e '\e[48:2:1:2:3m\eP$qm\e\\' | xxd)
 
 ^[P1$r48:2:1:2:3m^[\
 00000000: 1b50 3124 7234 383a 323a 313a 323a 336d  .P1$r48:2:1:2:3m


### PR DESCRIPTION
This example prints the escape sequence to standard out, then launches `xxd`which waits for input on standard input.
```
$ (echo -e '\e[48:2:1:2:3m\eP$qm\e\\' ; xxd)
```

Change the `;` to a pipe send the escape sequence into `xxd`
```
$ (echo -e '\e[48:2:1:2:3m\eP$qm\e\\' | xxd)
```

Example output:
```
$ (echo -e '\e[48:2:1:2:3m\eP$qm\e\\' | xxd)
00000000: 1b5b 3438 3a32 3a31 3a32 3a33 6d1b 5024  .[48:2:1:2:3m.P$
00000010: 716d 1b5c 0a                             qm.\.
```