### PR TITLE
xterm and urxvt

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,16 +278,17 @@ another section.
 ## Partial Support
 
 These terminal emulators parse ANSI color sequences, but approximate the true
-color using a palette. A 256-color (8-bit) palette is used unless specified.
+color using a palette or limit number of true colors that can be used at the
+same time. A 256-color (8-bit) palette is used unless specified.
 
 - [mlterm](http://mlterm.sourceforge.net) - built with **--with-gtk=3.0**
   configure flag. Approximates colors using a 512-color embedded palette
   (https://sourceforge.net/p/mlterm/bugs/74/)
 - [urxvt aka rxvt-unicode](http://software.schmorp.de/pkg/rxvt-unicode.html) -
   since
-  [revision 1.570](http://cvs.schmorp.de/rxvt-unicode/src/command.C?revision=1.570&view=markup&sortby=log&sortdir=down)
-  http://lists.schmorp.de/pipermail/rxvt-unicode/2016q2/002261.html (Note there
-  is a restriction of colors count still)
+  [revision 1.570](http://cvs.schmorp.de/rxvt-unicode/src/command.C?revision=1.570&view=markup&sortby=log&sortdir=down).
+  Limits maximum number of colors:
+  http://lists.schmorp.de/pipermail/rxvt-unicode/2016q2/002261.html
 - Linux console ([fbcon](https://www.kernel.org/doc/Documentation/fb/fbcon.txt)), [since v3.16](https://github.com/torvalds/linux/commit/cec5b2a97a11ade56a701e83044d0a2a984c67b4) - https://bugzilla.kernel.org/show_bug.cgi?id=79551 (downgraded to 16 foregrounds and 8 backgrounds)
 
 #### Note about color differences


### PR DESCRIPTION
Bisected xterm to be sure. Log entry is:
```
add optional support for direct-colors (adapted from patch by anonymous “Nibby Nebbulous”).
```

Fixes #13