### PR TITLE
Add clifm to the list of truecolor programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ complex and may perform very slowly if used blindly [2].
 
 ## Console Programs Supporting Truecolor
 
+- [clifm](https://github.com/leo-arch/clifm) - The command line file manager
 - [dte](https://gitlab.com/craigbarnes/dte) text editor - (since [version 1.8](https://craigbarnes.gitlab.io/dte/releases.html#v1.8))
 - [elinks](https://repo.or.cz/w/elinks.git) - [configure.in:1410](https://repo.or.cz/w/elinks.git/blob/HEAD:/configure.in#l1410) (./configure --enable-true-color)
 - [emacs](https://www.gnu.org/software/emacs/) - since [26.1 release](https://lists.gnu.org/archive/html/emacs-devel/2018-05/msg00765.html)
@@ -343,7 +344,6 @@ complex and may perform very slowly if used blindly [2].
 - [tv](https://github.com/daleroberts/tv) - tool to quickly view high-resolution multi-band imagery directly in terminal
 - [vifm](https://github.com/vifm/vifm) file manager - since 0.12 version
 - [vim](https://github.com/vim/vim) - (from 7.4.1770); need to set [termguicolors](https://github.com/vim/vim/blob/master/runtime/doc/version8.txt#L202) to enable truecolor.
-- [clifm](https://github.com/leo-arch/clifm) - The command line file manager
 
 ## Console Programs Not Supporting Truecolor
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ complex and may perform very slowly if used blindly [2].
 - [tv](https://github.com/daleroberts/tv) - tool to quickly view high-resolution multi-band imagery directly in terminal
 - [vifm](https://github.com/vifm/vifm) file manager - since 0.12 version
 - [vim](https://github.com/vim/vim) - (from 7.4.1770); need to set [termguicolors](https://github.com/vim/vim/blob/master/runtime/doc/version8.txt#L202) to enable truecolor.
+- [clifm](https://github.com/leo-arch/clifm) - The command line file manager
 
 ## Console Programs Not Supporting Truecolor
 


### PR DESCRIPTION
As the title says, add [clifm](https://github.com/leo-arch/clifm) to the list of programs supporting truecolor. 